### PR TITLE
Fix dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ gemspec
 
 gem 'activeadmin', github: 'activeadmin'
 gem 'inherited_resources'
-gem 'spinjs-rails'
 
 group :development do
   # Debugging

--- a/activeadmin_polymorphic.gemspec
+++ b/activeadmin_polymorphic.gemspec
@@ -16,4 +16,6 @@ Gem::Specification.new do |s|
 
   s.files         = `git ls-files`.split("\n").sort
   s.test_files    = `git ls-files -- {spec,features}/*`.split("\n")
+
+  s.add_dependency 'spinjs-rails', '~> 1.4'
 end

--- a/lib/activeadmin_polymorphic.rb
+++ b/lib/activeadmin_polymorphic.rb
@@ -1,3 +1,4 @@
+require "spinjs-rails"
 require "activeadmin_polymorphic/engine"
 require "activeadmin_polymorphic/form_builder"
 

--- a/lib/activeadmin_polymorphic/version.rb
+++ b/lib/activeadmin_polymorphic/version.rb
@@ -1,3 +1,3 @@
 module ActiveadminPolymorphic
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end


### PR DESCRIPTION
- Add spinjs-rails as a gem dependency instead

This should perhaps be done with activeadmin as well
