### PR TITLE
Trigger ajax:complete event for parent form as well.

### DIFF
--- a/app/assets/javascripts/activeadmin_polymorphic.js.coffee
+++ b/app/assets/javascripts/activeadmin_polymorphic.js.coffee
@@ -185,11 +185,17 @@ window.remoteSubmit = (target, callback) ->
     xhr.setRequestHeader 'Accept', 'application/json'
   .trigger('submit.rails')
     .on 'ajax:aborted:file', (inputs) ->
+      $(parentForm).trigger('ajax:complete.rails')
+
       false
     .on 'ajax:error', (event, response, status) ->
+      $(parentForm).trigger('ajax:complete.rails')
+
       if response.status == 422
         loadErrors(target)
     .on 'ajax:success', (event, object, status, response) ->
+      $(parentForm).trigger('ajax:complete.rails')
+
       unless $(target).next().find('input:first').val() # create
         $(target).next().find('input:first').val(object.id)
         # replace new form with edit form


### PR DESCRIPTION
We're using submit form button with "disable-with" feature and when
form is submitted with errors in the polymorphic content "disable-with"
is not removed from the form submit button since parent form is not
getting "ajax:complete" event and it's not possible to submit form again.